### PR TITLE
🎨 管理画面のナビに患者一覧へのリンクを設置とディレクトリ構造変更

### DIFF
--- a/front-end/src/app/doctor/layout.tsx
+++ b/front-end/src/app/doctor/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { usePathname } from "next/navigation";
-import DoctorDashboardLayout from "../features/doctor/dashboard/DoctorDashboardLayout";
+import DoctorDashboardLayout from "../features/doctor/layout/DoctorDashboardLayout";
 
 export default function Layout({
   children,

--- a/front-end/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
+++ b/front-end/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
@@ -3,6 +3,7 @@ import { useDisclosure } from "@mantine/hooks";
 import style from "./layout.module.scss";
 import useDoctorLogout from "@/app/hooks/useDoctorLogout";
 import React, { FC, ReactNode } from "react";
+import Link from "next/link";
 
 type Props = {
   children: ReactNode;
@@ -28,6 +29,9 @@ const DoctorDashboardLayout: FC<Props> = React.memo((props) => {
       </AppShell.Header>
 
       <AppShell.Navbar className={style.nav}>
+        <Link href={`/doctor/patients-list`}>
+          <Button component="a">患者一覧</Button>
+        </Link>
         <Button onClick={handleClickLogout}>ログアウト</Button>
       </AppShell.Navbar>
 

--- a/front-end/src/app/features/doctor/layout/layout.module.scss
+++ b/front-end/src/app/features/doctor/layout/layout.module.scss
@@ -8,6 +8,22 @@
 
 .nav{
   button{
+    width: 100%;
+    background: none;
+    transition: background 0.2s ease,color 0.2s ease;
+    &.current{
+      background: #ffffff;
+      color:var(--mantine-color-body);
+    }
+    &:not(.current){
+      &:hover{
+        background: #ffffff;
+        color:var(--mantine-color-body);
+      }
+    }
+  }
+  a{
+    width: 100%;
     background: none;
     transition: background 0.2s ease,color 0.2s ease;
     &.current{


### PR DESCRIPTION
- 管理画面のサイドナビに患者一覧へのリンクを設置
- DoctorDashboardLayout と同階層の layout.scss のコンポーネントの親フォルダ名を dashboard から layout に変更