### PR TITLE
💄 レイアウトのカラーを変更とcssからjsで定義し直し

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -92,7 +92,7 @@ app.post("/doctor/logout", async (req: Request, res: Response) => {
     });
 });
 
-app.get("/patients", async (req: Request, res: Response) => {
+app.get("/doctor/patients", async (req: Request, res: Response) => {
     if (!req.session) {
         return res.status(401).json({ error: "不正なアクセスです。" })
     }

--- a/frontend/src/app/doctor/login/page.module.scss
+++ b/frontend/src/app/doctor/login/page.module.scss
@@ -1,5 +1,5 @@
 .loginPage {
-  background: var(--mantine-color-body);
+  background: var(--mantine-color-brand-1);
   min-height: 100dvh;
   display: flex;
   align-items: center;
@@ -7,13 +7,11 @@
 
 .container{
   background-color: white;
-  color:var(--mantine-em-color)
+  h1{
+    color:var(--mantine-color-brand-3)
+  }
 }
 
 .header {
   padding: 2rem 0;
-}
-
-.form{
-  color:var(--main-color)
 }

--- a/frontend/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
+++ b/frontend/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
@@ -14,6 +14,7 @@ const DoctorDashboardLayout: FC<Props> = React.memo((props) => {
   const { handleClickLogout } = useDoctorLogout();
   return (
     <AppShell
+      className={style.body}
       header={{ height: 60 }}
       navbar={{
         width: 300,

--- a/frontend/src/app/features/doctor/layout/layout.module.scss
+++ b/frontend/src/app/features/doctor/layout/layout.module.scss
@@ -1,39 +1,30 @@
+.body{
+  background: var(--mantine-color-brand-1);
+}
+
 .header {
   color: #ffffff;
-  padding: var(--mantine-spacing-md);;
+  padding: var(--mantine-spacing-md);
+  background: var(--mantine-color-brand-3);
   display: flex;
   align-items: center;
   gap: 10px;
 }
 
 .nav{
-  button{
+  background: var(--mantine-color-brand-3);
+  button,a{
     width: 100%;
     background: none;
     transition: background 0.2s ease,color 0.2s ease;
     &.current{
       background: #ffffff;
-      color:var(--mantine-color-body);
+      color:var(--mantine-color-brand-3);
     }
     &:not(.current){
       &:hover{
         background: #ffffff;
-        color:var(--mantine-color-body);
-      }
-    }
-  }
-  a{
-    width: 100%;
-    background: none;
-    transition: background 0.2s ease,color 0.2s ease;
-    &.current{
-      background: #ffffff;
-      color:var(--mantine-color-body);
-    }
-    &:not(.current){
-      &:hover{
-        background: #ffffff;
-        color:var(--mantine-color-body);
+        color:var(--mantine-color-brand-3);
       }
     }
   }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,6 +1,17 @@
+:root {
+  --button-bg: #f3a011; /* ボタンの背景色 */
+  --button-hover: #f3a011; /* ボタンのホバー時の背景色 */
+  --input-color: #f3a011;
+}
+
 body {
-  --mantine-color-body: rgba(243, 145, 17, 0.5);
-  --mantine-em-color: rgb(243, 145, 17);
-  --main-color: #764a1b;
-  color: var(--main-color);
+  --mantine-color-text: #764a1b;
+}
+
+button {
+  transition: opacity 0.2s ease;
+}
+
+button:hover {
+  opacity: 0.8;
 }

--- a/frontend/src/app/util/theme.ts
+++ b/frontend/src/app/util/theme.ts
@@ -7,7 +7,6 @@ export const theme = createTheme({
     "MS PGothic", sans-serif`,
     primaryColor: 'brand',
     colors: {
-        //body: ['#764a1b'], // カスタムカラーを追加
         brand: [
             '#F6A94B', '#F5A03F', '#F59B2D', '#F39111', '#D87A0E', '#B5640B',
             '#9E4F09', '#8A4407', '#733608',

--- a/frontend/src/app/util/theme.ts
+++ b/frontend/src/app/util/theme.ts
@@ -1,15 +1,16 @@
 import { createTheme } from "@mantine/core";
 
 export const theme = createTheme({
-    fontFamily: 'sans-serif',
-    primaryColor: 'orange',
+    fontFamily: `"Helvetica Neue", "Hiragino Sans",
+    "Hiragino Kaku Gothic ProN", "ヒラギノ角ゴ Pro W3",
+    "Hiragino Kaku Gothic Pro", "メイリオ", Meiryo, Osaka, "ＭＳ Ｐゴシック",
+    "MS PGothic", sans-serif`,
+    primaryColor: 'brand',
     colors: {
-        orange: [
-            '#fff4e6', '#ffe8cc', '#ffd8a8', '#ffc078', '#ffa94d', '#ff922b',
-            '#fd7e14', '#f76707', '#e8590c', '#d9480f',
+        //body: ['#764a1b'], // カスタムカラーを追加
+        brand: [
+            '#F6A94B', '#F5A03F', '#F59B2D', '#F39111', '#D87A0E', '#B5640B',
+            '#9E4F09', '#8A4407', '#733608',
         ],
     },
-    // text: {
-    //     color: 'var(--mantine-color-orange-6)', // 全体のデフォルトフォントカラー
-    // },
 });


### PR DESCRIPTION
- フロントエンド
	- レイアウトやフォントのカラーをcssで定義していたものを theme.ts で定義し直し。
	- レイアウトやフォントのカラーを変更
	- レイアウトのフォントファミリーを変更
- バックエンド
	- 既存のAPIのパスを変更