### PR TITLE
✨ カテゴリテーブルに親カテゴリIDを設置するカラムを追加

### DIFF
--- a/backend/prisma/migrations/20240927001346_2024_09_27/migration.sql
+++ b/backend/prisma/migrations/20240927001346_2024_09_27/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "categories" ADD COLUMN     "parent_id" INTEGER;

--- a/backend/prisma/migrations/20240927003802_2024_09_27_v1_1/migration.sql
+++ b/backend/prisma/migrations/20240927003802_2024_09_27_v1_1/migration.sql
@@ -1,0 +1,2 @@
+-- AddForeignKey
+ALTER TABLE "categories" ADD CONSTRAINT "categories_parent_id_fkey" FOREIGN KEY ("parent_id") REFERENCES "categories"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -60,10 +60,14 @@ model medical_records {
 }
 
 model categories {
-  id                 Int                  @id @default(autoincrement())
-  treatment          String
-  created_at         DateTime             @default(now())
-  updated_at         DateTime             @default(now())
+  id         Int          @id @default(autoincrement())
+  treatment  String
+  parent_id  Int?
+  created_at DateTime     @default(now())
+  updated_at DateTime     @default(now())
+  parent     categories?  @relation("CategoryParent", fields: [parent_id], references: [id])
+  children   categories[] @relation("CategoryParent")
+
   medical_categories medical_categories[]
 }
 
@@ -74,6 +78,6 @@ model medical_categories {
   created_at        DateTime @default(now())
   updated_at        DateTime @default(now())
 
-  medical_record medical_records @relation(fields: [medical_record_id], references: [id], onDelete: Cascade)
-  category       categories      @relation(fields: [category_id], references: [id], onDelete: Cascade)
+  medical_records medical_records @relation(fields: [medical_record_id], references: [id], onDelete: Cascade)
+  categories      categories      @relation(fields: [category_id], references: [id], onDelete: Cascade)
 }

--- a/common/types/CategoriesType.ts
+++ b/common/types/CategoriesType.ts
@@ -1,0 +1,4 @@
+export type CategoriesType = {
+    id: number;
+    treatment: string,
+}

--- a/common/types/MedicalRecordsType.ts
+++ b/common/types/MedicalRecordsType.ts
@@ -1,0 +1,12 @@
+import { CategoriesType } from "./CategoriesType";
+
+type MedicalCategoriesType = {
+    categories: Pick<CategoriesType, "treatment">;
+}
+
+export type MedicalRecordsType = {
+    id: number;
+    patient_id: number;
+    examination_at: Date;
+    medical_categories: MedicalCategoriesType[]
+}

--- a/frontend/src/app/doctor/patients-list/page.tsx
+++ b/frontend/src/app/doctor/patients-list/page.tsx
@@ -1,7 +1,5 @@
 "use client";
-import "@mantine/core/styles.css";
-import "@mantine/dates/styles.css"; //if using mantine date picker features
-import "mantine-react-table/styles.css"; //make sure MRT styles were imported in your app root (once)
+
 import { useEffect, useMemo } from "react";
 import { MantineReactTable, type MRT_ColumnDef } from "mantine-react-table";
 import Link from "next/link";

--- a/frontend/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
+++ b/frontend/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
@@ -1,3 +1,7 @@
+import "@mantine/core/styles.css";
+import "@mantine/dates/styles.css"; //if using mantine date picker features
+import "mantine-react-table/styles.css"; //make sure MRT styles were imported in your app root (once)
+
 import { AppShell, Burger, Button, Title } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import style from "./layout.module.scss";


### PR DESCRIPTION
- カテゴリテーブルに親カテゴリIDを設置するカラムを追加し、自己結合できるように変更
- 診察履歴一覧を取得するAPIと患者情報を取得するAPIを設定
-  mantine-react-table のcssファイの読み込み場所を/app/[features/doctor/layout/DoctorDashboardLayout.tsxに変更し、doctor管理画面の全ページで使えるように変更