### PR TITLE
✨ 診察履歴の作成・更新を行うためのAPIを作成

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,8 @@ import cors from "cors";
 import { DoctorType } from "../../common/types/DoctorType";
 import { PatientType } from "../../common/types/PatientType";
 import { MedicalRecordsType } from "../../common/types/MedicalRecordsType";
+import { BasicCategoriesType } from "../../common/types/BasicCategoriesType";
+import { MedicalRecordsCategoryType } from "../../common/types/MedicalRecordsCategoryType";
 
 // SessionDataに独自の型を生やす
 declare module 'express-session' {
@@ -29,6 +31,7 @@ app.use(cors({
     credentials: true
 }))
 
+app.set('trust proxy', 1) // trust first proxy
 app.use(session({
     secret: process.env.DOCTOR_SESSION_SECRET_KEY,
     resave: false,
@@ -49,6 +52,8 @@ const doctorSessionCheck = (req: Request, res: Response, next: NextFunction) => 
     }
     next(); // セッションがあれば次の処理に進む
 };
+
+const prisma = new PrismaClient();
 
 // 患者のデータ取得
 app.get("/patients/:patient_id", doctorSessionCheck, async (req: Request, res: Response) => {
@@ -91,18 +96,13 @@ app.post("/doctor/login", async (req: Request, res: Response) => {
         const sessionUUID = uuidv4();
         req.session.sessionId = sessionUUID;  // UUIDをセッションIDとして保存
         req.session.userId = doctor.id; // 実際のデータベースIDも必要に応じて保存
-
         return res.json({
             message: "ログインに成功しました。",
-            sessionId: sessionUUID,  // UUIDをクライアントに返す（通常は必要ないが、場合によっては返す）
-            doctor: {
-                id: doctor.id, // クライアント側で必要な情報だけを返す
-                name: doctor.name,
-                email: doctor.email
-            }
+            sessionId: sessionUUID,
+            userId: req.session.userId,
         });
     } catch (e) {
-        return res.status(400).json(e)
+        return res.status(400).json(e);
     }
 })
 
@@ -113,33 +113,78 @@ app.post("/doctor/logout", async (req: Request, res: Response) => {
             return res.status(500).json({ message: 'Failed to log out' });
         }
         res.clearCookie(sessionName);  // クッキーの削除
-        res.json({ message: 'Logout successful' });
+        res.json({ message: 'ログアウトしました。' });
     });
 });
+
+// doctor session 情報を取得してログインしているユーザーの情報を取得する
+app.get("/doctor/login_doctor", async (req: Request, res: Response) => {
+    if (req.session.userId) {
+        try {
+            const doctor: DoctorType = await prisma.doctors.findFirst({
+                where: {
+                    AND: [
+                        { id: req.session.userId }
+                    ]
+                }
+            })
+            return res.json(doctor)
+        } catch (e) {
+            return res.status(400).json({ error: "データの取得に失敗しました。" });
+        }
+    } else {
+        res.status(401).json({ error: 'セッションがありません' });
+    }
+});
+
+// 医者一覧を取得
+app.get("/doctor/doctors", doctorSessionCheck, async (req: Request, res: Response) => {
+    try {
+        const allDoctors: DoctorType[] = await prisma.doctors.findMany({
+            select: {
+                id: true,
+                name: true,
+                email: true
+            }
+        });
+        return res.json(allDoctors);
+    } catch (e) {
+        return res.status(400).json({ error: "データの取得に失敗しました。" });
+    }
+})
 
 // 患者一覧を取得する
 app.get("/doctor/patients", doctorSessionCheck, async (req: Request, res: Response) => {
     try {
         const allPatients: PatientType[] = await prisma.patients.findMany();
-        return res.json(allPatients)
+        return res.json(allPatients);
     } catch (e) {
-        return res.status(400).json({ error: "データの取得に失敗しました。" })
+        return res.status(400).json({ error: "データの取得に失敗しました。" });
     }
 })
 
+type ResultMedicalRecordsType = Omit<MedicalRecordsType, "categories"> & {
+    medical_categories: {
+        categories: BasicCategoriesType;
+    }[]
+}
+
 // 選択した患者の診察履歴一覧を取得する
-app.get("/doctor/medical_records/:patient_id", doctorSessionCheck, async (req: Request, res: Response) => {
+app.get("/doctor/medical_records/:patient_id", async (req: Request, res: Response) => {
     try {
         const { patient_id }: { patient_id: number } = req.body;
-        const allMedicalRecords: MedicalRecordsType[] = await prisma.medical_records.findMany({
+        const resultAllMedicalRecords: ResultMedicalRecordsType[] = await prisma.medical_records.findMany({
             select: {
                 id: true,
                 patient_id: true,
                 examination_at: true,
+                medical_memo: true,
+                doctor_memo: true,
                 medical_categories: {
                     select: {
                         categories: {
                             select: {
+                                id: true,
                                 treatment: true
                             }
                         }
@@ -150,14 +195,25 @@ app.get("/doctor/medical_records/:patient_id", doctorSessionCheck, async (req: R
                 patient_id
             }
         });
-        return res.json(allMedicalRecords)
+        const allMedicalRecords: MedicalRecordsType[] = resultAllMedicalRecords.map((result) => {
+            const { id, patient_id, examination_at, medical_memo, doctor_memo, medical_categories } = result;
+            return {
+                id,
+                patient_id,
+                examination_at,
+                medical_memo,
+                doctor_memo,
+                categories: medical_categories.flatMap((category) => category.categories)
+            }
+        })
+        return res.json(allMedicalRecords);
     } catch (e) {
-        return res.status(400).json({ error: "データの取得に失敗しました。" })
+        return res.status(400).json({ error: "データの取得に失敗しました。" });
     }
 })
 
 // カテゴリを取得する
-app.get('/doctor/categories', doctorSessionCheck, async (req: Request, res: Response) => {
+app.get("/doctor/categories", doctorSessionCheck, async (req: Request, res: Response) => {
     try {
         const allCategories = await prisma.categories.findMany({
             select: {
@@ -174,12 +230,136 @@ app.get('/doctor/categories', doctorSessionCheck, async (req: Request, res: Resp
                 parent_id: null
             }
         });
-        return res.json(allCategories)
+        return res.json(allCategories);
     } catch (e) {
-        return res.status(400).json({ error: "データの取得に失敗しました。" })
+        return res.status(400).json({ error: "データの取得に失敗しました。" });
     }
 });
 
-const prisma = new PrismaClient();
+type PutMedicalRecordsType = Omit<MedicalRecordsType, "categories"> & { categories: string[] }
+
+app.put("/doctor/medical_records", async (req: Request, res: Response) => {
+    try {
+        const { id, patient_id, medical_memo, doctor_memo, categories }: PutMedicalRecordsType = req.body;
+        const updated_at: Date = new Date();
+        const medicalRecordId: number = Number(id);
+        const categoryNumbers: number[] = categories.map((category) => Number(category))
+        const result = await prisma.$transaction(async (prisma) => {
+            await prisma.medical_records.update({
+                where: { id: medicalRecordId },
+                data: {
+                    patient_id,
+                    medical_memo,
+                    doctor_memo,
+                    updated_at
+                },
+            });
+            // 1. 現在の medical_categories を取得
+            const existingCategories = await prisma.medical_categories.findMany({
+                where: {
+                    medical_record_id: medicalRecordId,
+                },
+            });
+
+            const existingCategoryIds: number[] = existingCategories.map(cat => cat.category_id);
+
+            // 2. 削除すべきカテゴリを特定
+            const categoriesToDelete: number[] = existingCategoryIds.filter(
+                categoryId => !categoryNumbers.includes(categoryId)
+            );
+
+            // 3. 追加すべきカテゴリを特定
+            const categoriesToAdd: number[] = categoryNumbers.filter(
+                categoryId => !existingCategoryIds.includes(categoryId)
+            );
+
+            // 4. 削除
+            if (categoriesToDelete.length > 0) {
+                await prisma.medical_categories.deleteMany({
+                    where: {
+                        medical_record_id: medicalRecordId,
+                        category_id: { in: categoriesToDelete },
+                    },
+                });
+            }
+
+            // 5. 追加
+            if (categoriesToAdd.length > 0) {
+                const newMedicalCategories: MedicalRecordsCategoryType[] = categoriesToAdd.map(categoryId => ({
+                    medical_record_id: medicalRecordId,
+                    category_id: categoryId,
+                }));
+
+                await prisma.medical_categories.createMany({
+                    data: newMedicalCategories,
+                });
+            }
+        })
+        return res.json({ data: result })
+    } catch (e) {
+        return res.status(400).json({ error: "データの更新に失敗しました。" });
+    }
+})
+
+type PostMedicalRecordsType = PutMedicalRecordsType & { doctor_id: string };
+
+app.post("/doctor/medical_records", async (req: Request, res: Response) => {
+    try {
+        const { patient_id, doctor_id, medical_memo, doctor_memo, categories }: PostMedicalRecordsType = req.body;
+        const postDoctorId = Number(doctor_id);
+        const examination_at = new Date();
+        const result = await prisma.$transaction(async (prisma) => {
+            const newMedicalRecord = await prisma.medical_records.create({
+                data: {
+                    doctor_id: postDoctorId,
+                    patient_id,
+                    medical_memo,
+                    doctor_memo,
+                    examination_at
+                }
+            });
+
+            const medicalRecordId = newMedicalRecord.id;
+            if (categories.length) {
+                const postMedicalCategoriesData = categories.map((category) => (
+                    {
+                        medical_record_id: medicalRecordId,
+                        category_id: Number(category)
+                    }
+                ))
+
+                await prisma.medical_categories.createMany({
+                    data: postMedicalCategoriesData
+                });
+            }
+        })
+        return res.json({ data: result })
+    } catch (e) {
+        return res.status(400).json({ error: "データの保存に失敗しました。" });
+    }
+})
+
+app.delete("/doctor/medical_records", async (req: Request, res: Response) => {
+    try {
+        const { id } = req.body;
+        const result = await prisma.$transaction(async (prisma) => {
+            const targetId = Number(id);
+            await prisma.medical_records.delete({
+                where: {
+                    id: targetId
+                }
+            });
+
+            await prisma.medical_categories.deleteMany({
+                where: {
+                    id: targetId
+                }
+            });
+        })
+        return res.json({ data: result })
+    } catch (e) {
+        return res.status(400).json({ error: "データの削除に失敗しました。" });
+    }
+});
 
 app.listen(PORT, () => console.log("server is running"))

--- a/common/types/MedicalRecordsCategoryType.ts
+++ b/common/types/MedicalRecordsCategoryType.ts
@@ -1,0 +1,4 @@
+export type MedicalRecordsCategoryType = {
+    medical_record_id: number;
+    category_id: number;
+}

--- a/common/types/MedicalRecordsType.ts
+++ b/common/types/MedicalRecordsType.ts
@@ -1,12 +1,10 @@
 import { BasicCategoriesType } from "./BasicCategoriesType";
 
-type MedicalCategoriesType = {
-    categories: Pick<BasicCategoriesType, "treatment">;
-}
-
 export type MedicalRecordsType = {
     id: number;
     patient_id: number;
+    medical_memo: string;
+    doctor_memo: string;
     examination_at: Date;
-    medical_categories: MedicalCategoriesType[]
+    categories: BasicCategoriesType[]
 }

--- a/common/types/MedicalRecordsType.ts
+++ b/common/types/MedicalRecordsType.ts
@@ -3,6 +3,7 @@ import { BasicCategoriesType } from "./BasicCategoriesType";
 export type MedicalRecordsType = {
     id: number;
     patient_id: number;
+    doctor_id: number;
     medical_memo: string;
     doctor_memo: string;
     examination_at: Date;

--- a/frontend/src/app/doctor/layout.tsx
+++ b/frontend/src/app/doctor/layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { usePathname } from "next/navigation";
 import DoctorDashboardLayout from "../features/doctor/layout/DoctorDashboardLayout";
+import GlobalDoctorProvider from "../providers/GlobalDoctorContext";
 
 export default function Layout({
   children,
@@ -11,6 +12,10 @@ export default function Layout({
   if ("/doctor/login" === pathname) {
     return <>{children}</>;
   } else {
-    return <DoctorDashboardLayout>{children}</DoctorDashboardLayout>;
+    return (
+      <GlobalDoctorProvider>
+        <DoctorDashboardLayout>{children}</DoctorDashboardLayout>
+      </GlobalDoctorProvider>
+    );
   }
 }

--- a/frontend/src/app/doctor/patients-list/page.tsx
+++ b/frontend/src/app/doctor/patients-list/page.tsx
@@ -1,19 +1,15 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useMemo } from "react";
 import { MantineReactTable, type MRT_ColumnDef } from "mantine-react-table";
 import Link from "next/link";
 import { Button, Title } from "@mantine/core";
-import { usePatientsList } from "@/app/hooks/usePatientsList";
 import { PatientType } from "@/../../common/types/PatientType";
 import { sexList } from "../../../../constants/sexList";
+import { useGlobalDoctor } from "@/app/hooks/useGlobalDoctor";
 
 const Page = () => {
-  const { data, patients, setPatients } = usePatientsList();
-
-  useEffect(() => {
-    data && setPatients(data);
-  }, [data, setPatients]);
+  const { patients } = useGlobalDoctor();
 
   const columns = useMemo<MRT_ColumnDef<PatientType>[]>(
     () => [

--- a/frontend/src/app/features/doctor/components/MedicalRecordForm.tsx
+++ b/frontend/src/app/features/doctor/components/MedicalRecordForm.tsx
@@ -97,7 +97,7 @@ const MedicalRecordForm: FC<Props> = React.memo(
                 form.setFieldValue("doctor_memo", e.currentTarget.value)
               }
             />
-            <Button type="submit">{getName ? "更新" : "作成"}</Button>
+            <Button type="submit">{data === null ? "保存" : "更新"}</Button>
           </Flex>
         </Flex>
       </form>

--- a/frontend/src/app/features/doctor/components/MedicalRecordForm.tsx
+++ b/frontend/src/app/features/doctor/components/MedicalRecordForm.tsx
@@ -1,0 +1,110 @@
+import {
+  Autocomplete,
+  Button,
+  Flex,
+  MultiSelect,
+  Select,
+  Textarea,
+} from "@mantine/core";
+import React, { FC } from "react";
+import { MedicalRecordsType } from "../../../../../../common/types/MedicalRecordsType";
+import useMedicalRecordForm from "@/app/hooks/useMedicalRecordForm";
+
+type Props = {
+  name: string;
+  data: MedicalRecordsType | null;
+  mutate: () => void;
+  modalClosed: () => void;
+};
+
+const MedicalRecordForm: FC<Props> = React.memo(
+  ({ name, data, mutate, modalClosed }) => {
+    const {
+      getName,
+      patientNameSuggestions,
+      categories,
+      doctorsData,
+      form,
+      handleSubmit,
+    } = useMedicalRecordForm(name, data);
+    return (
+      <form
+        onSubmit={form.onSubmit(() =>
+          handleSubmit(form.values, mutate, modalClosed)
+        )}
+      >
+        <Flex direction="column" gap="md">
+          <Flex gap="md">
+            <Autocomplete
+              label="患者様"
+              placeholder="患者名を入力してください"
+              data={patientNameSuggestions.map((patient) => patient.value)}
+              value={form.values.name}
+              readOnly={getName ? true : false}
+            />
+
+            <Select
+              label="担当者"
+              data={doctorsData}
+              {...form.getInputProps("doctor_id")}
+            />
+          </Flex>
+          <Flex direction="column" gap="md">
+            {categories?.map((parentCategories) => {
+              const childCategoriesData = parentCategories.children.map(
+                (childCategory) => ({
+                  value: childCategory.id.toString(),
+                  label: childCategory.treatment,
+                })
+              );
+              return (
+                <MultiSelect
+                  key={parentCategories.id}
+                  label={parentCategories.treatment}
+                  placeholder="選択してください"
+                  data={childCategoriesData}
+                  value={form.values.categories.filter((category) =>
+                    childCategoriesData.some(
+                      (child) => child.value === category
+                    )
+                  )}
+                  onChange={(value) => {
+                    // 選択された値をそのままセット
+                    form.setFieldValue("categories", [
+                      ...form.values.categories.filter(
+                        (cat) =>
+                          !childCategoriesData.some(
+                            (child) => child.value === cat
+                          )
+                      ),
+                      ...value,
+                    ]);
+                  }}
+                />
+              );
+            })}
+            <Textarea
+              label="メモ"
+              value={form.values.medical_memo}
+              onChange={(e) =>
+                form.setFieldValue("medical_memo", e.currentTarget.value)
+              }
+            />
+            <Textarea
+              label="お医者メモ"
+              value={form.values.doctor_memo}
+              onChange={(e) =>
+                form.setFieldValue("doctor_memo", e.currentTarget.value)
+              }
+            />
+            <Button type="submit">{getName ? "更新" : "作成"}</Button>
+          </Flex>
+        </Flex>
+      </form>
+    );
+  }
+);
+
+MedicalRecordForm.displayName = "MedicalRecordForm";
+
+export default MedicalRecordForm;

--- a/frontend/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
+++ b/frontend/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
@@ -7,7 +7,7 @@ import { useDisclosure } from "@mantine/hooks";
 import style from "./layout.module.scss";
 import useDoctorLogout from "@/app/hooks/useDoctorLogout";
 import React, { FC, ReactNode } from "react";
-import GlobalDoctorProvider from "@/app/providers/GlobalDoctorContext";
+import Link from "next/link";
 
 type Props = {
   children: ReactNode;
@@ -18,32 +18,31 @@ const DoctorDashboardLayout: FC<Props> = React.memo((props) => {
   const [opened, { toggle }] = useDisclosure();
   const { handleClickLogout } = useDoctorLogout();
   return (
-    <GlobalDoctorProvider>
-      <AppShell
-        className={style.body}
-        header={{ height: 60 }}
-        navbar={{
-          width: 300,
-          breakpoint: "sm",
-          collapsed: { mobile: !opened },
-        }}
-        padding="md"
-      >
-        <AppShell.Header className={style.header}>
-          <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
-          <Title order={2}>医心堂鍼灸整骨院</Title>
-        </AppShell.Header>
+    <AppShell
+      className={style.body}
+      header={{ height: 60 }}
+      navbar={{
+        width: 300,
+        breakpoint: "sm",
+        collapsed: { mobile: !opened },
+      }}
+      padding="md"
+    >
+      <AppShell.Header className={style.header}>
+        <Burger opened={opened} onClick={toggle} hiddenFrom="sm" size="sm" />
+        <Title order={2}>医心堂鍼灸整骨院</Title>
+      </AppShell.Header>
 
-        <AppShell.Navbar className={style.nav}>
-          <Button component="a" href={`/doctor/patients-list`}>
-            患者一覧
-          </Button>
-          <Button onClick={handleClickLogout}>ログアウト</Button>
-        </AppShell.Navbar>
+      <AppShell.Navbar className={style.nav}>
+        <Link href={`/doctor/patients-list`} passHref legacyBehavior>
+          <Button component="a">患者一覧</Button>
+        </Link>
 
-        <AppShell.Main>{children}</AppShell.Main>
-      </AppShell>
-    </GlobalDoctorProvider>
+        <Button onClick={handleClickLogout}>ログアウト</Button>
+      </AppShell.Navbar>
+
+      <AppShell.Main>{children}</AppShell.Main>
+    </AppShell>
   );
 });
 

--- a/frontend/src/app/features/doctor/medical_records/MedicalRecordsContents.tsx
+++ b/frontend/src/app/features/doctor/medical_records/MedicalRecordsContents.tsx
@@ -3,7 +3,8 @@ import useMedicalRecords from "@/app/hooks/useMedicalRecords";
 import React, { useMemo } from "react";
 import { MantineReactTable, MRT_ColumnDef } from "mantine-react-table";
 import { MedicalRecordsType } from "../../../../../../common/types/MedicalRecordsType";
-import { Box, Button, Flex, List, ListItem } from "@mantine/core";
+import { Box, Button, Flex, List, ListItem, Modal, Text } from "@mantine/core";
+import MedicalRecordForm from "../components/MedicalRecordForm";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
@@ -17,7 +18,15 @@ dayjs.extend(utc);
 dayjs.extend(timezone);
 
 const MedicalRecordsContents = React.memo(({ name, patients_id }: Props) => {
-  const { medicalRecord } = useMedicalRecords(patients_id);
+  const {
+    medicalRecord,
+    selectedRecord,
+    patientMutate,
+    setSelectedRecord,
+    isNewRecord,
+    setIsNewRecord,
+    modalFormatData,
+  } = useMedicalRecords(patients_id);
   const columns = useMemo<MRT_ColumnDef<MedicalRecordsType>[]>(
     () => [
       {
@@ -28,41 +37,76 @@ const MedicalRecordsContents = React.memo(({ name, patients_id }: Props) => {
             row.original.examination_at
           ).utc();
           const setTimeZone: dayjs.Dayjs = examination_at.tz("Asia/Tokyo");
-          const format: string = setTimeZone.format("YY年m月D日 H:i:s");
+          const format: string = setTimeZone.format("YYYY年M月D日 H:mm");
           return format;
         },
         maxSize: 200,
       },
       {
-        accessorKey: "medical_categories",
+        accessorKey: "category",
         header: "施術",
-        Cell: ({ row }) => {
-          return (
-            <List>
-              {row.original.medical_categories.map((categories, i) => (
-                <ListItem key={i}>{categories.categories.treatment}</ListItem>
-              ))}
-            </List>
-          );
-        },
+        Cell: ({ row }) => (
+          <List>
+            {row.original.categories.map((category, i) => (
+              <ListItem key={i}>{category.treatment}</ListItem>
+            ))}
+          </List>
+        ),
       },
       {
         header: "操作",
         Cell: ({ row }) => (
           <>
-            <Button>編集</Button>
+            <Button
+              onClick={() => {
+                setIsNewRecord(false);
+                setSelectedRecord(row.original);
+              }}
+            >
+              編集
+            </Button>
           </>
         ),
         maxSize: 80,
       },
     ],
-    []
+    [setIsNewRecord, setSelectedRecord]
   );
   return (
     <>
+      {/* 診察編集モーダル */}
+      <Modal
+        opened={selectedRecord !== null || isNewRecord} // モーダルの開閉状態を診察データで管理
+        onClose={() => {
+          setSelectedRecord(null);
+          setIsNewRecord(false);
+        }} // モーダルを閉じるときはnullに戻す
+        title={
+          <Flex gap="md">
+            <Text>{isNewRecord ? "新しい診察を作成" : "診察編集"}</Text>
+            <Text>診察日: {modalFormatData}</Text>
+          </Flex>
+        }
+        keepMounted
+      >
+        <MedicalRecordForm
+          name={name}
+          data={selectedRecord || null}
+          mutate={patientMutate}
+          modalClosed={() => setSelectedRecord(null)}
+        />
+      </Modal>
+
       <Box py={30}>
         <Flex justify="center" gap={50}>
-          <Button>新しい診察を作成</Button>
+          <Button
+            onClick={() => {
+              setSelectedRecord(null);
+              setIsNewRecord(true);
+            }}
+          >
+            新しい診察を作成
+          </Button>
           <Button>患者情報を編集</Button>
         </Flex>
       </Box>

--- a/frontend/src/app/hooks/useMedicalRecordForm.ts
+++ b/frontend/src/app/hooks/useMedicalRecordForm.ts
@@ -61,9 +61,18 @@ const useMedicalRecordForm = (name: string, data: MedicalRecordsType | null) => 
             form.setValues({
                 id: data.id.toString(),
                 categories: getCategories,
-                doctor_id: loginDoctor?.id.toString(),
+                doctor_id: data?.doctor_id.toString(),
                 medical_memo: data.medical_memo,
                 doctor_memo: data.doctor_memo
+            })
+        } else {
+            form.setValues({
+                id: "",
+                name,
+                doctor_id: loginDoctor?.id.toString(),
+                categories: [],
+                medical_memo: "",
+                doctor_memo: ""
             })
         }
     }, [data])
@@ -79,7 +88,7 @@ const useMedicalRecordForm = (name: string, data: MedicalRecordsType | null) => 
             method,
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify({
-                id: Number(id),
+                id: id ? Number(id) : 0,
                 doctor_id: Number(doctor_id),
                 patient_id,
                 medical_memo,

--- a/frontend/src/app/hooks/useMedicalRecordForm.ts
+++ b/frontend/src/app/hooks/useMedicalRecordForm.ts
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useState } from "react";
+import { useGlobalDoctor } from "./useGlobalDoctor";
+import { useForm } from "@mantine/form";
+import { MedicalRecordsType } from "../../../../common/types/MedicalRecordsType";
+import { API_URL } from "../../../constants/url";
+
+type PatientNameSuggestionsType = {
+    value: string;
+    id: string
+};
+
+type FormValues = {
+    id: string;
+    name: string;
+    doctor_id: string;
+    categories: string[];
+    medical_memo: string;
+    doctor_memo: string;
+}
+
+const useMedicalRecordForm = (name: string, data: MedicalRecordsType | null) => {
+    const { patients, loginDoctor, categories, doctors } = useGlobalDoctor();
+    const [submitError, setSubmitError] = useState<string>("");
+    // 患者の名前をサジェストするためのリストを準備
+    const patientNameSuggestions: PatientNameSuggestionsType[] = useMemo(() => {
+        return patients ? patients.map(patient => ({
+            value: patient.name,
+            id: patient.id.toString()
+        })) : [];
+    }, [patients])
+
+    const getName: string = name;
+    const getPatient = patients ? patients?.find((patient) => patient.name === getName) : null;
+
+    const getCategories = data
+        ? data.categories.map((category) => category.id.toString())
+        : [];
+
+    const form = useForm({
+        initialValues: {
+            id: "",
+            name,
+            doctor_id: "",
+            categories: [""],
+            medical_memo: "",
+            doctor_memo: ""
+        }
+    })
+
+    const doctorsData = doctors?.map((doctor) => ({
+        value: doctor.id.toString(),
+        label: doctor.name,
+    }));
+
+    useEffect(() => {
+        if (data) {
+            const getCategories = data
+                ? data.categories.map((category) => category.id.toString())
+                : [];
+
+            form.setValues({
+                id: data.id.toString(),
+                categories: getCategories,
+                doctor_id: loginDoctor?.id.toString(),
+                medical_memo: data.medical_memo,
+                doctor_memo: data.doctor_memo
+            })
+        }
+    }, [data])
+
+
+    const handleSubmit = async (values: FormValues, doMutate: () => void, modalClosed: () => void) => {
+        setSubmitError("");
+        const { id, name, doctor_id, medical_memo, doctor_memo, categories } = values;
+        const patientData = patients?.find((patient) => patient.name === name);
+        const patient_id = patientData ? Number(patientData.id) : 0;
+        const method = id ? "PUT" : "POST";
+        const response = await fetch(`${API_URL}/doctor/medical_records`, {
+            method,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                id: Number(id),
+                doctor_id: Number(doctor_id),
+                patient_id,
+                medical_memo,
+                doctor_memo,
+                categories
+            }),
+        });
+
+        if (!response.ok) {
+            const errorData = await response.json();  // サーバーからのエラーメッセージを取得
+            setSubmitError(errorData.error);
+            alert(submitError);
+            return;
+        } else {
+            setSubmitError("")
+            alert("PUT" === method ? "データを更新しました。" : "データを保存しました。")
+            doMutate()
+            modalClosed();
+            return;
+        }
+    }
+
+    const handleDelete = async (values: FormValues, doMutate: () => void, modalClosed: () => void) => {
+        setSubmitError("");
+        const { id } = values;
+        const response = await fetch(`${API_URL}/doctor/medical_records`, {
+            method: "DELETE",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                id: Number(id),
+            }),
+        });
+        if (!response.ok) {
+            const errorData = await response.json();  // サーバーからのエラーメッセージを取得
+            setSubmitError(errorData.error);
+            alert(submitError);
+            return;
+        } else {
+            setSubmitError("")
+            alert("データを削除しました。")
+            doMutate()
+            modalClosed();
+            return;
+        }
+    }
+
+    return { getName, getPatient, loginDoctor, getCategories, patientNameSuggestions, categories, doctorsData, form, handleSubmit, handleDelete }
+}
+
+export default useMedicalRecordForm

--- a/frontend/src/app/hooks/useMedicalRecords.ts
+++ b/frontend/src/app/hooks/useMedicalRecords.ts
@@ -1,7 +1,13 @@
 import useSWR, { useSWRConfig } from 'swr';
 import { API_URL } from '../../../constants/url';
 import { MedicalRecordsType } from "@/../../common/types/MedicalRecordsType";
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 async function fetcher(key: string): Promise<MedicalRecordsType[]> {
     return fetch(key).then((res) => res.json());
@@ -10,6 +16,19 @@ async function fetcher(key: string): Promise<MedicalRecordsType[]> {
 const useMedicalRecords = (patients_id: number) => {
     const fetchUrl = `${API_URL}/doctor/medical_records/${patients_id}`;
     const [medicalRecord, setMedicalRecord] = useState<MedicalRecordsType[] | null>([]);
+
+    const [selectedRecord, setSelectedRecord] =
+        useState<MedicalRecordsType | null>(null);
+    const [isNewRecord, setIsNewRecord] = useState<boolean>(false);
+    const modalFormatData = useMemo(() => {
+        const examination_at: dayjs.Dayjs = dayjs(
+            selectedRecord ? selectedRecord.examination_at : new Date()
+        ).utc();
+        const setTimeZone: dayjs.Dayjs = examination_at.tz("Asia/Tokyo");
+        const format: string = setTimeZone.format("YYYY年M月D日 H:mm");
+        return format;
+    }, [selectedRecord]);
+
     const { data, isLoading, error } = useSWR(
         fetchUrl,
         fetcher
@@ -20,7 +39,7 @@ const useMedicalRecords = (patients_id: number) => {
 
     const { mutate } = useSWRConfig();
 
-    const doMutate = () => {
+    const patientMutate = () => {
         mutate(fetchUrl);
     }
 
@@ -28,7 +47,12 @@ const useMedicalRecords = (patients_id: number) => {
         medicalRecord,
         isLoading,
         error,
-        doMutate
+        patientMutate,
+        selectedRecord,
+        setSelectedRecord,
+        isNewRecord,
+        setIsNewRecord,
+        modalFormatData
     }
 }
 


### PR DESCRIPTION
- 診察履歴の作成・更新を行うためのAPIを作成
- ログインしている医者の情報・カテゴリ一覧・医者一覧・患者一覧をdoctor管理画面の中で使い回せるようにする
- グローバル化させるファイルを変更
-  患者一覧ページ 患者データをProvider から取得出来るように変更
- 診察情報をモーダルで作成・更新できるよに設定。