### PR TITLE
🔧 タイプスクリプトエラー修正

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -180,7 +180,6 @@ app.get("/doctor/medical_records/:patient_id", async (req: Request, res: Respons
                 medical_memo: true,
                 doctor_memo: true,
                 doctor_id: true,
-                delFlag: true,
                 medical_categories: {
                     select: {
                         categories: {


### PR DESCRIPTION
- delFlag は enum 形式だったので string 型ではなく prisma client から取得して設定できるように変更
- typescript のエラーを修正