### PR TITLE
🎨 クッキーのhttpOnly属性を外部ファイルから読み込む形に変更

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,4 @@ node_modules
 # Keep environment variables out of version control
 .env
 build
+constants/session.ts

--- a/backend/constants/session.ts
+++ b/backend/constants/session.ts
@@ -1,0 +1,1 @@
+export const setHttpOnly: boolean = true;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,6 +11,7 @@ import { MedicalRecordsCategoryType } from "../../common/types/MedicalRecordsCat
 import { v4 as uuidv4 } from 'uuid';
 import { ParsedQs } from 'qs';
 import dayjs from "dayjs";
+import { setHttpOnly } from "../constants/session";
 // SessionDataに独自の型を生やす
 declare module 'express-session' {
     interface SessionData {
@@ -39,7 +40,7 @@ app.use(session({
     name: sessionName,
     cookie: {
         secure: false, // HTTPSを使用
-        httpOnly: true, // XSS攻撃を防ぐ
+        httpOnly: setHttpOnly, // XSS攻撃を防ぐ
         sameSite: 'lax',
         maxAge: 24 * 60 * 60 * 1000 // セッションの有効期限を設定（例: 24時間）
     }


### PR DESCRIPTION
- backend の cookie の httpOnly をローカルではfalse、本番環境ではtrue にしたいので、左記の設定のみ別ファイルにして、gitigoneで追跡させないように設定を試す