### PR TITLE
🎨  path を /doctor 配下に限定とコンソールログの設定

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -41,6 +41,9 @@ app.use(cors({
     credentials: true
 }))
 
+console.log(process.env.DOCTOR_SESSION_SECURE)
+console.log(typeof process.env.DOCTOR_SESSION_SECURE)
+
 app.set('trust proxy', 1) // trust first proxy
 app.use(session({
     store: new PgSessionStore({
@@ -56,7 +59,8 @@ app.use(session({
         secure: process.env.DOCTOR_SESSION_SECURE === "true", // HTTPSを使用
         httpOnly: true, // XSS攻撃を防ぐ
         sameSite: 'lax',
-        maxAge: 24 * 60 * 60 * 1000 // セッションの有効期限を設定（例: 24時間）
+        maxAge: 24 * 60 * 60 * 1000, // セッションの有効期限を設定（例: 24時間）
+        path: "/doctor" // "/doctor"以下のリクエストでのみクッキーを送信
     }
 }))
 


### PR DESCRIPTION
- doctor 配下でしか使わないので  path を追加
- secure の値を確認するためのコンソールログ設定