### PR TITLE
🎨 患者一覧ページのテーブルコンテンツだけをCSRにする

### DIFF
--- a/frontend/src/app/doctor/patients-list/page.tsx
+++ b/frontend/src/app/doctor/patients-list/page.tsx
@@ -1,62 +1,17 @@
-"use client";
+import { Title } from "@mantine/core";
+import PatientsListContents from "@/app/features/doctor/patients-list/PatientsListContents";
+import { Metadata } from "next";
 
-import { useMemo } from "react";
-import { MantineReactTable, type MRT_ColumnDef } from "mantine-react-table";
-import Link from "next/link";
-import { Button, Title } from "@mantine/core";
-import { PatientType } from "@/../../common/types/PatientType";
-import { sexList } from "../../../../constants/sexList";
-import { useGlobalDoctor } from "@/app/hooks/useGlobalDoctor";
-
+export const metadata: Metadata = {
+  title: "患者一覧",
+};
 const Page = () => {
-  const { patients } = useGlobalDoctor();
-
-  const columns = useMemo<MRT_ColumnDef<PatientType>[]>(
-    () => [
-      {
-        accessorKey: "id",
-        header: "ID",
-        maxSize: 40,
-      },
-      {
-        accessorKey: "name",
-        header: "名前",
-        maxSize: 100,
-      },
-      {
-        accessorKey: "sex",
-        header: "性別",
-        Cell: ({ row }) => sexList[row.original.sex].label,
-        maxSize: 40,
-      },
-      {
-        accessorKey: "address",
-        header: "住所",
-      },
-
-      {
-        header: "操作",
-        Cell: ({ row }) => (
-          <Link
-            href={`/doctor/medical_records?patients_id=${row.original.id}`}
-            passHref
-            legacyBehavior
-          >
-            <Button component="a">選択</Button>
-          </Link>
-        ),
-        maxSize: 80,
-      },
-    ],
-    []
-  );
-
   return (
     <>
       <Title order={1} py={30}>
         患者一覧
       </Title>
-      {patients && <MantineReactTable columns={columns} data={patients} />}
+      <PatientsListContents />
     </>
   );
 };

--- a/frontend/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
+++ b/frontend/src/app/features/doctor/layout/DoctorDashboardLayout.tsx
@@ -8,6 +8,7 @@ import style from "./layout.module.scss";
 import useDoctorLogout from "@/app/hooks/useDoctorLogout";
 import React, { FC, ReactNode } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 type Props = {
   children: ReactNode;
@@ -15,6 +16,7 @@ type Props = {
 
 const DoctorDashboardLayout: FC<Props> = React.memo((props) => {
   const { children } = props;
+  const pathname = usePathname();
   const [opened, { toggle }] = useDisclosure();
   const { handleClickLogout } = useDoctorLogout();
   return (
@@ -35,7 +37,14 @@ const DoctorDashboardLayout: FC<Props> = React.memo((props) => {
 
       <AppShell.Navbar className={style.nav}>
         <Link href={`/doctor/patients-list`} passHref legacyBehavior>
-          <Button component="a">患者一覧</Button>
+          <Button
+            component="a"
+            className={
+              pathname === `/doctor/patients-list` ? style.current : ""
+            }
+          >
+            患者一覧
+          </Button>
         </Link>
 
         <Button onClick={handleClickLogout}>ログアウト</Button>

--- a/frontend/src/app/features/doctor/patients-list/PatientsListContents.tsx
+++ b/frontend/src/app/features/doctor/patients-list/PatientsListContents.tsx
@@ -1,0 +1,19 @@
+"use client";
+import { MantineReactTable } from "mantine-react-table";
+import React, { FC } from "react";
+import useDoctorPatientList from "@/app/hooks/useDoctorPatientList";
+import { useGlobalDoctor } from "@/app/hooks/useGlobalDoctor";
+
+const PatientsListContents: FC<Record<string, never>> = React.memo(() => {
+  const { columns } = useDoctorPatientList();
+  const { patients } = useGlobalDoctor();
+  return patients ? (
+    <MantineReactTable columns={columns} data={patients} />
+  ) : (
+    ""
+  );
+});
+
+PatientsListContents.displayName = "PatientsListContents";
+
+export default PatientsListContents;

--- a/frontend/src/app/hooks/useDoctorPatientList.tsx
+++ b/frontend/src/app/hooks/useDoctorPatientList.tsx
@@ -1,0 +1,51 @@
+import { MRT_ColumnDef } from "mantine-react-table";
+import React, { useMemo } from "react";
+import { PatientType } from "../../../../common/types/PatientType";
+import { sexList } from "../../../constants/sexList";
+import Link from "next/link";
+import { Button } from "@mantine/core";
+
+const useDoctorPatientList = () => {
+  const columns = useMemo<MRT_ColumnDef<PatientType>[]>(
+    () => [
+      {
+        accessorKey: "id",
+        header: "ID",
+        maxSize: 40,
+      },
+      {
+        accessorKey: "name",
+        header: "名前",
+        maxSize: 100,
+      },
+      {
+        accessorKey: "sex",
+        header: "性別",
+        Cell: ({ row }) => sexList[row.original.sex].label,
+        maxSize: 40,
+      },
+      {
+        accessorKey: "address",
+        header: "住所",
+      },
+
+      {
+        header: "操作",
+        Cell: ({ row }) => (
+          <Link
+            href={`/doctor/medical_records?patients_id=${row.original.id}`}
+            passHref
+            legacyBehavior
+          >
+            <Button component="a">選択</Button>
+          </Link>
+        ),
+        maxSize: 80,
+      },
+    ],
+    []
+  );
+  return { columns };
+};
+
+export default useDoctorPatientList;


### PR DESCRIPTION
- 患者一覧ページのテーブルコンテンツをCSRとして分けることでヘッダーやタイトルなどをSSRとして扱うようにする
- 患者一覧ページにいるときはサイドナビの「患者一覧」にカレントを当てる