### PR TITLE
🐛 クッキーの有効期限を設定し直す

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -65,7 +65,8 @@ app.use(session({
         secure: process.env.DOCTOR_SESSION_SECURE === "true", // HTTPSを使用
         httpOnly: true, // XSS攻撃を防ぐ
         sameSite: 'none',
-        path: "/doctor"
+        path: "/doctor",
+        maxAge: 1 * 24 * 60 * 60 * 1000
     }
 }))
 

--- a/frontend/constants/cookieOption.ts
+++ b/frontend/constants/cookieOption.ts
@@ -1,4 +1,5 @@
-export const doctorCookieOptions: { path: string, secure: boolean, httpOnly: boolean } = {
+export const doctorCookieOptions: { maxAge: number, path: string, secure: boolean, httpOnly: boolean } = {
+    maxAge: 1 * 24 * 60 * 60,
     path: '/doctor',
     secure: process.env.NEXT_DOCTOR_SESSION_SECURE === 'true', // HTTPSでのみ送信
     httpOnly: false,


### PR DESCRIPTION
- クッキーの有効期限を設定を解除したらシークレットブラウザでログイン後にエラーが出たのでクッキーの有効期限を設定し直す