### PR TITLE
🎨 トークンとログインステータスをdoctor配下のページでグローバルコンテキスト化する

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -94,7 +94,7 @@ const doctorLoginCheck = (request: Request, response: Response, next: NextFuncti
     }
 
     // トークンを検証
-    jwt.verify(token, process.env.JWT_SECRET_KEY, (err, decoded) => {
+    verify(token, process.env.JWT_SECRET_KEY, (err, decoded) => {
         if (err) {
             return response.status(403).json({ error: 'ログインの有効期限が切れている可能性があります。' });
         }

--- a/frontend/src/app/doctor/layout.tsx
+++ b/frontend/src/app/doctor/layout.tsx
@@ -2,6 +2,7 @@
 import { usePathname } from "next/navigation";
 import DoctorDashboardLayout from "../features/doctor/layout/DoctorDashboardLayout";
 import GlobalDoctorProvider from "../providers/GlobalDoctorContext";
+import GlobalDoctorLoginProvider from "../providers/GlobalDoctorLoginContext";
 
 export default function Layout({
   children,
@@ -10,12 +11,14 @@ export default function Layout({
 }>) {
   const pathname = usePathname();
   if ("/doctor/login" === pathname) {
-    return <>{children}</>;
+    return <GlobalDoctorLoginProvider>{children}</GlobalDoctorLoginProvider>;
   } else {
     return (
-      <GlobalDoctorProvider>
-        <DoctorDashboardLayout>{children}</DoctorDashboardLayout>
-      </GlobalDoctorProvider>
+      <GlobalDoctorLoginProvider>
+        <GlobalDoctorProvider>
+          <DoctorDashboardLayout>{children}</DoctorDashboardLayout>
+        </GlobalDoctorProvider>
+      </GlobalDoctorLoginProvider>
     );
   }
 }

--- a/frontend/src/app/hooks/useDoctorEdit.ts
+++ b/frontend/src/app/hooks/useDoctorEdit.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { API_URL } from '../../../constants/url';
 import { useRouter } from 'next/navigation';
 import setShowNotification from '../../../constants/setShowNotification';
-import { useGlobalDoctor } from './useGlobalDoctor';
+import { useGlobalDoctorLogin } from './useGlobalDoctorLogin';
 
 type FormValues = {
     name: string;
@@ -22,7 +22,7 @@ async function getDoctorFetcher([id, token]: [number, string | null]): Promise<D
 }
 
 const useDoctorEdit = (id: number | null) => {
-    const { token } = useGlobalDoctor();
+    const { token } = useGlobalDoctorLogin();
     const router = useRouter();
 
     const [submitError, setSubmitError] = useState<string>("");

--- a/frontend/src/app/hooks/useDoctorLogin.ts
+++ b/frontend/src/app/hooks/useDoctorLogin.ts
@@ -6,6 +6,7 @@ import { useDisclosure } from "@mantine/hooks";
 import { setCookie } from "cookies-next";
 import { doctorCookieKeyName } from "../../../constants/cookieKey";
 import { doctorCookieOptions } from "../../../constants/cookieOption";
+import { useGlobalDoctorLogin } from "./useGlobalDoctorLogin";
 
 type FormValues = {
     email: string;
@@ -14,6 +15,7 @@ type FormValues = {
 
 const useDoctorLogin = () => {
     const router = useRouter();
+    const { setIsLogin } = useGlobalDoctorLogin();
     const [visible, { open, close }] = useDisclosure(false);
     const [loginError, setLoginError] = useState<string>("");
 
@@ -55,9 +57,10 @@ const useDoctorLogin = () => {
             const data = await response.json()
             localStorage.setItem('token', data.token);
             setCookie(doctorCookieKeyName, data.token, doctorCookieOptions);
+            setIsLogin(true);
             router.push('/doctor/patients-list');
         }
-    }, [router, open, close]);
+    }, [router, open, close, setIsLogin]);
 
     return { form, handleLogin, loginError, visible }
 }

--- a/frontend/src/app/hooks/useDoctorLogout.ts
+++ b/frontend/src/app/hooks/useDoctorLogout.ts
@@ -2,11 +2,14 @@ import { deleteCookie } from "cookies-next";
 import { useRouter } from "next/navigation";
 import { doctorCookieKeyName } from "../../../constants/cookieKey";
 import { doctorCookieOptions } from "../../../constants/cookieOption";
+import { useGlobalDoctorLogin } from "./useGlobalDoctorLogin";
 
 const useDoctorLogout = () => {
     const router = useRouter();
+    const { setIsLogin } = useGlobalDoctorLogin();
     const handleClickLogout = async () => {
         deleteCookie(doctorCookieKeyName, doctorCookieOptions);
+        setIsLogin(false);
         localStorage.removeItem('token');
         router.push('/doctor/login');
     }

--- a/frontend/src/app/hooks/useGlobalDoctorLogin.ts
+++ b/frontend/src/app/hooks/useGlobalDoctorLogin.ts
@@ -1,0 +1,4 @@
+import { useContext } from "react";
+import { GlobalDoctorLoginContext, GlobalDoctorLoginContextType } from "../providers/GlobalDoctorLoginContext";
+
+export const useGlobalDoctorLogin = (): GlobalDoctorLoginContextType => useContext(GlobalDoctorLoginContext)

--- a/frontend/src/app/hooks/useMedicalRecordForm.ts
+++ b/frontend/src/app/hooks/useMedicalRecordForm.ts
@@ -6,6 +6,7 @@ import { MedicalRecordsType } from "../../../../common/types/MedicalRecordsType"
 import { API_URL } from "../../../constants/url";
 import dayjs from "dayjs";
 import setShowNotification from "../../../constants/setShowNotification";
+import { useGlobalDoctorLogin } from "./useGlobalDoctorLogin";
 
 type FormValues = {
     id: string;
@@ -18,7 +19,8 @@ type FormValues = {
 }
 
 const useMedicalRecordForm = (name: string, data: MedicalRecordsType | null) => {
-    const { patients, loginDoctor, categories, doctors, token } = useGlobalDoctor();
+    const { token } = useGlobalDoctorLogin();
+    const { patients, loginDoctor, categories, doctors } = useGlobalDoctor();
     const [submitError, setSubmitError] = useState<string>("");
 
     const getName: string = name;

--- a/frontend/src/app/hooks/useMedicalRecords.tsx
+++ b/frontend/src/app/hooks/useMedicalRecords.tsx
@@ -7,7 +7,7 @@ import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
 import { Button, List, ListItem } from "@mantine/core";
 import { MRT_ColumnDef } from "mantine-react-table";
-import { useGlobalDoctor } from "./useGlobalDoctor";
+import { useGlobalDoctorLogin } from "./useGlobalDoctorLogin";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -26,7 +26,7 @@ async function fetcher([url, token]: [string, string | null]): Promise<
 }
 
 const useMedicalRecords = (patients_id: number) => {
-  const { token } = useGlobalDoctor();
+  const { token } = useGlobalDoctorLogin();
   const fetchUrl = `${API_URL}/doctor/medical_records/${patients_id}`;
   const [medicalRecord, setMedicalRecord] = useState<
     MedicalRecordsType[] | null

--- a/frontend/src/app/hooks/usePatientsList.ts
+++ b/frontend/src/app/hooks/usePatientsList.ts
@@ -2,7 +2,7 @@ import useSWR from "swr";
 import { API_URL } from "../../../constants/url";
 import { PatientType } from "../../../../common/types/PatientType";
 import { useState } from "react";
-import { useGlobalDoctor } from "./useGlobalDoctor";
+import { useGlobalDoctorLogin } from "./useGlobalDoctorLogin";
 
 async function fetcher([url, token]: [string, string | null]): Promise<PatientType[]> {
     return token
@@ -16,7 +16,7 @@ async function fetcher([url, token]: [string, string | null]): Promise<PatientTy
 }
 
 export const usePatientsList = () => {
-    const { token } = useGlobalDoctor();
+    const { token } = useGlobalDoctorLogin();
     const [patients, setPatients] = useState<PatientType[] | null>([]);
 
     const fetchUrl: string = `${API_URL}/doctor/patients`

--- a/frontend/src/app/providers/GlobalDoctorContext.tsx
+++ b/frontend/src/app/providers/GlobalDoctorContext.tsx
@@ -7,6 +7,7 @@ import { DoctorType } from "@/../../common/types/DoctorType";
 import { PatientType } from "../../../../common/types/PatientType";
 import { PatientNameSuggestionsType } from "../types/PatientNameSuggestionsTypes";
 import { SexTypes } from "@/../../common/types/SexTypes";
+import { useGlobalDoctorLogin } from "../hooks/useGlobalDoctorLogin";
 
 export type GlobalDoctorContextType = {
   loginDoctor: DoctorType | null;
@@ -19,7 +20,6 @@ export type GlobalDoctorContextType = {
   patientsMutate: () => void;
   patientNameSuggestions: PatientNameSuggestionsType[];
   sexList: SexTypes;
-  token: string | null;
 };
 
 export const GlobalDoctorContext = createContext<GlobalDoctorContextType>(
@@ -83,12 +83,11 @@ async function patientsFetcher([url, token]: [string, string | null]): Promise<
 
 const GlobalDoctorProvider = (props: { children: ReactNode }) => {
   const { children } = props;
+  const { isLogin, token } = useGlobalDoctorLogin();
   const loginDoctorFetchUrl = `${API_URL}/doctor/login_doctor`;
   const categoriesFetchUrl = `${API_URL}/doctor/categories`;
   const doctorsFetchUrl = `${API_URL}/doctor/doctors`;
   const patientsFetchUrl: string = `${API_URL}/doctor/patients`;
-
-  const [token, setToken] = useState<string | null>(null);
 
   // ログインしている医者 データのステート管理
   const [loginDoctor, setLoginDoctor] = useState<DoctorType | null>(null);
@@ -98,11 +97,6 @@ const GlobalDoctorProvider = (props: { children: ReactNode }) => {
   const [doctors, setDoctors] = useState<DoctorType[] | null>([]);
   // 患者一覧データのステート管理
   const [patients, setPatients] = useState<PatientType[] | null>([]);
-
-  useEffect(() => {
-    const savedToken = localStorage.getItem("token");
-    setToken(savedToken);
-  }, []);
 
   const { data: loginDoctorData, mutate: loginDoMutate } = useSWR(
     [loginDoctorFetchUrl, token],
@@ -125,20 +119,20 @@ const GlobalDoctorProvider = (props: { children: ReactNode }) => {
   );
 
   useEffect(() => {
-    loginDoctorData && setLoginDoctor(loginDoctorData);
-  }, [loginDoctorData, setLoginDoctor]);
+    isLogin && loginDoctorData && setLoginDoctor(loginDoctorData);
+  }, [isLogin, loginDoctorData, setLoginDoctor]);
 
   useEffect(() => {
-    categoriesData && setCategories(categoriesData);
-  }, [categoriesData, setCategories]);
+    isLogin && categoriesData && setCategories(categoriesData);
+  }, [isLogin, categoriesData, setCategories]);
 
   useEffect(() => {
-    doctorsData && setDoctors(doctorsData);
-  }, [doctorsData, setDoctors]);
+    isLogin && doctorsData && setDoctors(doctorsData);
+  }, [isLogin, doctorsData, setDoctors]);
 
   useEffect(() => {
-    patientsData && setPatients(patientsData);
-  }, [patientsData, setPatients]);
+    isLogin && patientsData && setPatients(patientsData);
+  }, [isLogin, patientsData, setPatients]);
 
   // 患者の名前をサジェストするためのリストを準備
   const patientNameSuggestions: PatientNameSuggestionsType[] = useMemo(() => {
@@ -180,7 +174,6 @@ const GlobalDoctorProvider = (props: { children: ReactNode }) => {
         patientsMutate,
         patientNameSuggestions,
         sexList,
-        token,
       }}
     >
       {children}

--- a/frontend/src/app/providers/GlobalDoctorLoginContext.tsx
+++ b/frontend/src/app/providers/GlobalDoctorLoginContext.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { getCookie } from "cookies-next";
+import { createContext, ReactNode, useEffect, useState } from "react";
+import { doctorCookieKeyName } from "../../../constants/cookieKey";
+
+export type GlobalDoctorLoginContextType = {
+  token: string | null;
+  setToken: (token: string | null) => void;
+  isLogin: boolean;
+  setIsLogin: (bool: boolean) => void;
+};
+
+export const GlobalDoctorLoginContext =
+  createContext<GlobalDoctorLoginContextType>(
+    {} as GlobalDoctorLoginContextType
+  );
+
+const GlobalDoctorLoginProvider = (props: { children: ReactNode }) => {
+  const { children } = props;
+  const [isLogin, setIsLogin] = useState<boolean>(false);
+  const [token, setToken] = useState<string | null>(null);
+  const loadCookie = getCookie(doctorCookieKeyName);
+
+  useEffect(() => {
+    loadCookie && setIsLogin(true);
+  }, [loadCookie]);
+
+  useEffect(() => {
+    isLogin ? setToken(localStorage.getItem("token")) : setToken(null);
+  }, [isLogin]);
+
+  return (
+    <GlobalDoctorLoginContext.Provider
+      value={{
+        token,
+        setToken,
+        isLogin,
+        setIsLogin,
+      }}
+    >
+      {children}
+    </GlobalDoctorLoginContext.Provider>
+  );
+};
+
+export default GlobalDoctorLoginProvider;


### PR DESCRIPTION
- 新しいコンテキストファイルを作成しトークンとログインステータスをdoctor配下のページでグローバル化する
- 上記の修正に伴い、tokenの呼び出し元（フック）の修正
- ロード時にクッキーがあればログイン状態をtrueにするよう修正し、ログインステータスの変更を監視してtrueになったらローカルストレージを見に行く様に変更