### PR TITLE
🐛 診察一覧ページの患者データの紐付け不具合修正

### DIFF
--- a/backend/src/doctor/medical_records.ts
+++ b/backend/src/doctor/medical_records.ts
@@ -18,7 +18,7 @@ type ResultMedicalRecordsType = Omit<MedicalRecordsType, "categories" | "delFlag
 // 選択した患者の診察履歴一覧を取得する
 router.get("/:patient_id", verifyAuthToken, async (request: Request, response: Response) => {
     try {
-        const { patient_id }: { patient_id: number } = request.body;
+        const patient_id = Number(request.params.patient_id);
         const { all, startDate, endDate } = request.query; // クエリパラメータから日付を取得
 
         // 現在の日付

--- a/frontend/src/app/doctor/medical-records/page.tsx
+++ b/frontend/src/app/doctor/medical-records/page.tsx
@@ -1,12 +1,21 @@
 import { notFound } from "next/navigation";
+import { cookies } from "next/headers";
 import { API_URL } from "../../../../constants/url";
 import { Metadata } from "next";
 import { PatientType } from "../../../../../common/types/PatientType";
 import { Title } from "@mantine/core";
 import MedicalRecordsContents from "@/app/features/doctor/medical-records/MedicalRecordsContents";
+import { doctorCookieKeyName } from "../../../../constants/cookieKey";
+import { getCookie } from "cookies-next";
 
 const getPatients = async (patients_id: number) => {
-  return await fetch(`${API_URL}/doctor/patients/${patients_id}`)
+  const token = getCookie(doctorCookieKeyName, { cookies });
+  return await fetch(`${API_URL}/doctor/patients/${patients_id}`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
     .then((res) => {
       const data: Promise<PatientType> = res.json();
       return data;


### PR DESCRIPTION
- 患者の診察履歴一覧にて患者のデータと紐づいておらず、患者さんの名前が出ていなかったり患者と紐づいた診察の取得ができていなかったので修正。
※原因は上記のページにて token を渡せていなかったため