### PR TITLE
fix: generateStaticParams プレースホルダー対応（Next.js 16 静的エクスポート）

### DIFF
--- a/frontend/src/app/doctor/edit-doctor/[doctor_id]/page.tsx
+++ b/frontend/src/app/doctor/edit-doctor/[doctor_id]/page.tsx
@@ -3,9 +3,9 @@ import { Title } from "@mantine/core";
 import { Metadata } from "next";
 
 // 静的エクスポート用（実データはクライアントサイドで SWR が取得）
-export const dynamicParams = false;
+// Next.js 16 の output: export は空配列不可のためプレースホルダーを返す
 export function generateStaticParams() {
-  return [];
+  return [{ doctor_id: "0" }];
 }
 
 type PageParams = {

--- a/frontend/src/app/doctor/edit-patient/[patient_id]/page.tsx
+++ b/frontend/src/app/doctor/edit-patient/[patient_id]/page.tsx
@@ -3,9 +3,9 @@ import { Title } from "@mantine/core";
 import { Metadata } from "next";
 
 // 静的エクスポート用（実データはクライアントサイドで SWR が取得）
-export const dynamicParams = false;
+// Next.js 16 の output: export は空配列不可のためプレースホルダーを返す
 export function generateStaticParams() {
-  return [];
+  return [{ patient_id: "0" }];
 }
 
 type PageParams = {


### PR DESCRIPTION
Next.js 16 + Turbopack では `generateStaticParams` が空配列を返すと「関数が存在しない」と同じ扱いになり build が失敗する。最低1件のプレースホルダーを返すことで回避。`dynamicParams = false` は削除しクライアントサイドで任意 ID に遷移できるようにする。