### PR TITLE
fix: medical-records を force-static に（静的エクスポート対応）

### DIFF
--- a/frontend/src/app/doctor/medical-records/page.tsx
+++ b/frontend/src/app/doctor/medical-records/page.tsx
@@ -6,6 +6,9 @@ import { Title } from "@mantine/core";
 import MedicalRecordsContents from "@/app/features/doctor/medical-records/MedicalRecordsContents";
 import { cookies } from "next/headers";
 import { doctorCookieName } from "../../../../../common/util/CookieName";
+// AWS 静的エクスポートでは searchParams は undefined になるため force-static で抑制
+export const dynamic = "force-static";
+
 const getPatients = async (
   patients_id: number
 ): Promise<PatientType | undefined> => {


### PR DESCRIPTION
searchParams + Cookie を使うサーバーサイドページは `output: export` と非互換。ビルドが通るよう `force-static` を追加。