### PR TITLE
fix: ECS Fargate 本番環境の不具合修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -54,10 +54,12 @@ COPY --from=builder /app/backend/build ./build
 COPY --from=builder /app/backend/prisma ./prisma
 COPY --from=builder /app/backend/node_modules/.prisma ./node_modules/.prisma
 COPY --from=builder /app/backend/node_modules/@prisma/client ./node_modules/@prisma/client
+COPY backend/migrate-supabase-to-rds.js ./
 
 RUN chown -R app:app /app
 USER app
 
 EXPOSE 8080
 
-CMD ["sh", "-c", "npx prisma migrate deploy && node build/backend/src/index.js"]
+# 起動順: マイグレーション → Supabase データ移行（空DBかつSUPABASE_URL設定時のみ） → サーバー起動
+CMD ["sh", "-c", "npx prisma migrate deploy && node migrate-supabase-to-rds.js && node build/backend/src/index.js"]

--- a/backend/migrate-supabase-to-rds.js
+++ b/backend/migrate-supabase-to-rds.js
@@ -1,0 +1,117 @@
+/**
+ * Supabase → RDS 全件データ移行スクリプト
+ *
+ * コンテナ起動時に自動実行される。
+ * doctors テーブルが空 かつ SUPABASE_URL が設定されている場合のみ移行する（冪等）。
+ *
+ * 手動実行:
+ *   cd /app/backend
+ *   SUPABASE_URL="postgres://..." node migrate-supabase-to-rds.js
+ */
+
+import pg from "pg";
+const { Pool } = pg;
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+
+if (!SUPABASE_URL) {
+  console.log("ℹ️  SUPABASE_URL 未設定のため移行をスキップ");
+  process.exit(0);
+}
+if (!process.env.DATABASE_URL) {
+  console.error("❌ DATABASE_URL が設定されていません");
+  process.exit(1);
+}
+
+const src = new Pool({ connectionString: SUPABASE_URL, ssl: { rejectUnauthorized: false } });
+const dst = new Pool({ connectionString: process.env.DATABASE_URL, ssl: { rejectUnauthorized: false } });
+
+async function run() {
+  console.log("🔌 接続確認中...");
+  await src.query("SELECT 1");
+  await dst.query("SELECT 1");
+  console.log("✅ 両 DB に接続できました");
+
+  // doctors が空でなければ移行済みとみなしてスキップ
+  const { rows: existing } = await dst.query("SELECT COUNT(*) FROM doctors");
+  if (Number(existing[0].count) > 0) {
+    console.log("ℹ️  RDS に既にデータがあるため移行をスキップ");
+    return;
+  }
+
+  console.log("🚀 移行開始...\n");
+
+  // ─── 既存データをクリア（念のため） ───────────────────────────────
+  await dst.query(
+    "TRUNCATE medical_categories, medical_records, categories, patients, doctors RESTART IDENTITY CASCADE"
+  );
+
+  // ─── doctors ────────────────────────────────────────────────────
+  await copyTable("doctors", ["id", "name", "password", "email", "created_at", "updated_at"]);
+
+  // ─── patients ───────────────────────────────────────────────────
+  await copyTable("patients", [
+    "id", "name", "sex", "tel", "address", "email", "password", "birth", "created_at", "updated_at",
+  ]);
+
+  // ─── categories（自己参照 → 2パスで挿入） ────────────────────────
+  console.log("📋 categories を移行中...");
+  const cats = await src.query('SELECT * FROM "categories" ORDER BY id');
+  for (const row of cats.rows) {
+    await dst.query(
+      `INSERT INTO "categories" (id, treatment, created_at, updated_at, parent_id)
+       VALUES ($1, $2, $3, $4, NULL) ON CONFLICT (id) DO NOTHING`,
+      [row.id, row.treatment, row.created_at, row.updated_at]
+    );
+  }
+  for (const row of cats.rows.filter((r) => r.parent_id != null)) {
+    await dst.query("UPDATE categories SET parent_id = $1 WHERE id = $2", [row.parent_id, row.id]);
+  }
+  await resetSeq("categories");
+  console.log(`   ✅ categories: ${cats.rows.length} 件\n`);
+
+  // ─── medical_records ────────────────────────────────────────────
+  await copyTable("medical_records", [
+    "id", "patient_id", "doctor_id", "medical_memo", "doctor_memo",
+    "examination_at", "created_at", "updated_at", '"delFlag"',
+  ]);
+
+  // ─── medical_categories ─────────────────────────────────────────
+  await copyTable("medical_categories", [
+    "id", "medical_record_id", "category_id", "created_at", "updated_at", '"delFlag"',
+  ]);
+
+  console.log("🎉 移行完了！");
+}
+
+async function copyTable(tableName, columns) {
+  console.log(`📋 ${tableName} を移行中...`);
+  const colsForSelect = columns.join(", ");
+  const res = await src.query(`SELECT ${colsForSelect} FROM "${tableName}" ORDER BY id`);
+  if (res.rows.length === 0) {
+    console.log(`   ⚠️  ${tableName}: データなし\n`);
+    return;
+  }
+  const plainCols = columns.map((c) => c.replace(/"/g, ""));
+  const colList = columns.join(", ");
+  const placeholders = columns.map((_, i) => `$${i + 1}`).join(", ");
+  for (const row of res.rows) {
+    await dst.query(
+      `INSERT INTO "${tableName}" (${colList}) VALUES (${placeholders}) ON CONFLICT (id) DO NOTHING`,
+      plainCols.map((c) => row[c])
+    );
+  }
+  await resetSeq(tableName);
+  console.log(`   ✅ ${tableName}: ${res.rows.length} 件\n`);
+}
+
+async function resetSeq(tableName) {
+  await dst.query(
+    `SELECT setval(pg_get_serial_sequence($1, 'id'), COALESCE((SELECT MAX(id) FROM "${tableName}"), 0))`,
+    [tableName]
+  );
+}
+
+run()
+  .catch((e) => { console.error("❌ エラー:", e.message); process.exit(1); })
+  .finally(async () => { await src.end(); await dst.end(); });

--- a/frontend/src/app/doctor/medical-records/page.tsx
+++ b/frontend/src/app/doctor/medical-records/page.tsx
@@ -1,60 +1,37 @@
-import { notFound } from "next/navigation";
-import { API_URL } from "../../../../constants/url";
-import { Metadata } from "next";
-import { PatientType } from "../../../../../common/types/PatientType";
+"use client";
+import { useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 import { Title } from "@mantine/core";
 import MedicalRecordsContents from "@/app/features/doctor/medical-records/MedicalRecordsContents";
-import { cookies } from "next/headers";
-import { doctorCookieName } from "../../../../../common/util/CookieName";
-// AWS 静的エクスポートでは searchParams は undefined になるため force-static で抑制
-export const dynamic = "force-static";
+import { PatientType } from "../../../../../common/types/PatientType";
+import { API_URL } from "../../../../constants/url";
 
-const getPatients = async (
-  patients_id: number
-): Promise<PatientType | undefined> => {
-  const cookieStore = cookies();
-  const token = (await cookieStore).get(doctorCookieName)?.value || "";
-  return await fetch(`${API_URL}/doctor/patients/${patients_id}`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-      Cookie: `${doctorCookieName}=${token}`,
-    },
+function MedicalRecordsInner() {
+  const searchParams = useSearchParams();
+  const patients_id = Number(searchParams.get("patients_id"));
+  const [patientData, setPatientData] = useState<PatientType | null>(null);
+  const [loading, setLoading] = useState(true);
 
-    credentials: "same-origin",
-  }).then((res) => res.json());
-};
-type QueryParamType = {
-  searchParams: Promise<{ [patients_id: string]: number | undefined }>;
-};
+  useEffect(() => {
+    if (!patients_id) {
+      setLoading(false);
+      return;
+    }
+    fetch(`${API_URL}/doctor/patients/${patients_id}`, {
+      credentials: "include",
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        setPatientData(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [patients_id]);
 
-export async function generateMetadata({
-  searchParams,
-}: QueryParamType): Promise<Metadata> {
-  // メタデータ（タイトル）設定
-  const errorTitle = "Not Found";
-  const patients_id = (await searchParams).patients_id;
-  if (!patients_id) {
-    return { title: errorTitle };
-  }
-  const patientsData: PatientType | undefined = await getPatients(patients_id);
-  if (!patientsData) {
-    return { title: errorTitle };
-  }
-  return {
-    title: `${patientsData.name} 様 編集画面`,
-  };
-}
+  if (!patients_id) return <div>患者が選択されていません</div>;
+  if (loading) return <div>Loading...</div>;
+  if (!patientData) return <div>データが見つかりません</div>;
 
-const Page = async ({ searchParams }: QueryParamType) => {
-  const patients_id = (await searchParams).patients_id;
-  if (!patients_id) {
-    notFound();
-  }
-  const patientData: PatientType | undefined = await getPatients(patients_id);
-  if (!patientData) {
-    notFound();
-  }
   return (
     <>
       <header>
@@ -62,12 +39,15 @@ const Page = async ({ searchParams }: QueryParamType) => {
           {patientData.name} 様
         </Title>
       </header>
-      <MedicalRecordsContents
-        patientData={patientData}
-        patients_id={patients_id}
-      />
+      <MedicalRecordsContents patientData={patientData} patients_id={patients_id} />
     </>
   );
-};
+}
 
-export default Page;
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <MedicalRecordsInner />
+    </Suspense>
+  );
+}

--- a/infra/cloudfront_s3.tf
+++ b/infra/cloudfront_s3.tf
@@ -2,6 +2,29 @@ resource "aws_s3_bucket" "front" {
   bucket = local.front_domain
 }
 
+# URL リライト: /doctor → /doctor/index.html（S3 は REST API 経由のためディレクトリ index を返さない）
+resource "aws_cloudfront_function" "url_rewrite" {
+  name    = "${var.project}-${var.environment}-url-rewrite"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+
+  code = <<-EOT
+    function handler(event) {
+      var request = event.request;
+      var uri = request.uri;
+      uri = uri.replace(/^(\/doctor\/edit-patient\/)([^\/]+)(\/.*)?$/, '$10/index.html');
+      uri = uri.replace(/^(\/doctor\/edit-doctor\/)([^\/]+)(\/.*)?$/, '$10/index.html');
+      if (uri.endsWith('/')) {
+        uri += 'index.html';
+      } else if (!uri.split('/').pop().includes('.')) {
+        uri += '/index.html';
+      }
+      request.uri = uri;
+      return request;
+    }
+  EOT
+}
+
 resource "aws_cloudfront_origin_access_control" "front" {
   name                              = "s3-front-oac"
   origin_access_control_origin_type = "s3"
@@ -28,6 +51,10 @@ resource "aws_cloudfront_distribution" "front" {
     forwarded_values {
       query_string = false
       cookies { forward = "none" }
+    }
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.url_rewrite.arn
     }
   }
 

--- a/infra/ecs.tf
+++ b/infra/ecs.tf
@@ -78,6 +78,26 @@ resource "aws_iam_role" "ecs_task" {
   })
 }
 
+# ECS Exec（aws ecs execute-command）に必要な SSM 権限
+resource "aws_iam_role_policy" "ecs_task_ssm" {
+  name = "ssm-exec"
+  role = aws_iam_role.ecs_task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel"
+      ]
+      Resource = "*"
+    }]
+  })
+}
+
 # ------------------------------------------------------------
 # ECS Task Definition (Fargate)
 # command で Prisma migrate deploy → API 起動
@@ -113,9 +133,11 @@ resource "aws_ecs_task_definition" "backend" {
     ]
 
     environment = [
-      { name = "NODE_ENV", value = "production" },
-      { name = "PORT", value = "8080" },
-      { name = "CLIENT_URL", value = var.client_url },
+      { name = "NODE_ENV",        value = "production" },
+      { name = "PORT",            value = "8080" },
+      { name = "CLIENT_URL",      value = var.client_url },
+      { name = "JWT_SECRET_KEY",  value = var.jwt_secret_key },
+      { name = "SUPABASE_URL",    value = var.supabase_url },
     ]
 
     secrets = [

--- a/infra/scripts/aws-apply.js
+++ b/infra/scripts/aws-apply.js
@@ -5,8 +5,18 @@ import { config } from "dotenv";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INFRA_DIR = resolve(__dirname, "..");
+const REPO_ROOT = resolve(INFRA_DIR, "..");
 
 config({ path: resolve(INFRA_DIR, ".env") });
+
+// backend/.env の DATABASE_URL を SUPABASE_URL として自動取得
+// （infra/.env に TF_VAR_supabase_url が未設定の場合のみ）
+if (!process.env.TF_VAR_supabase_url) {
+    const backendEnv = config({ path: resolve(REPO_ROOT, "backend", ".env"), override: false });
+    if (backendEnv.parsed?.DATABASE_URL) {
+        process.env.TF_VAR_supabase_url = backendEnv.parsed.DATABASE_URL;
+    }
+}
 
 const env = { ...process.env };
 const PROFILE = process.env.AWS_PROFILE;
@@ -18,6 +28,9 @@ const REQUIRED_VARS = [
     "TF_VAR_db_name",
     "TF_VAR_db_username",
     "TF_VAR_db_password",
+    "TF_VAR_client_url",
+    "TF_VAR_jwt_secret_key",
+    // TF_VAR_supabase_url は backend/.env の DATABASE_URL から自動取得するため任意
 ];
 const missing = REQUIRED_VARS.filter((k) => !process.env[k]);
 if (missing.length > 0) {

--- a/infra/scripts/aws-build-push.js
+++ b/infra/scripts/aws-build-push.js
@@ -11,6 +11,14 @@ const REPO_ROOT = resolve(INFRA_DIR, "..");
 
 config({ path: resolve(INFRA_DIR, ".env") });
 
+// backend/.env の DATABASE_URL を SUPABASE_URL として自動取得
+if (!process.env.TF_VAR_supabase_url) {
+    const backendEnv = config({ path: resolve(REPO_ROOT, "backend", ".env"), override: false });
+    if (backendEnv.parsed?.DATABASE_URL) {
+        process.env.TF_VAR_supabase_url = backendEnv.parsed.DATABASE_URL;
+    }
+}
+
 const PROFILE = process.env.AWS_PROFILE;
 const REGION = "ap-northeast-1";
 const env = { ...process.env };
@@ -64,12 +72,20 @@ try {
     run(`docker push ${ecrUrl}:${tag}`);
     run(`docker push ${ecrUrl}:latest`);
 
-    // 6. ECS サービス強制再デプロイ
-    console.log("\n🚀 Forcing ECS service redeploy...");
+    // 6. ECS サービス強制再デプロイ（最新タスク定義を明示指定）
+    console.log("\n🚀 Forcing ECS service redeploy with latest task definition...");
     const cluster = capture("terraform output -raw ecs_cluster_name", { cwd: INFRA_DIR });
     const service = capture("terraform output -raw ecs_service_name", { cwd: INFRA_DIR });
+
+    // ignore_changes = [task_definition] のため terraform apply はサービスを更新しない。
+    // ここで最新タスク定義 ARN を取得してサービスに明示的に反映させる。
+    const taskDefFamily = cluster.replace("-cluster", "-backend");
+    const latestTaskDefArn = capture(
+        `aws ecs describe-task-definition --task-definition ${taskDefFamily} --query taskDefinition.taskDefinitionArn --output text --region ${REGION} --profile ${PROFILE}`
+    );
+    console.log(`   Task definition: ${latestTaskDefArn}`);
     run(
-        `aws ecs update-service --cluster ${cluster} --service ${service} --force-new-deployment --region ${REGION} --profile ${PROFILE} --output text > /dev/null`
+        `aws ecs update-service --cluster ${cluster} --service ${service} --task-definition ${latestTaskDefArn} --force-new-deployment --region ${REGION} --profile ${PROFILE} --output text > /dev/null`
     );
 
     console.log("\n✅ Build & deploy triggered!");

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -28,6 +28,16 @@ variable "client_url" {
   default = ""
 }
 
+variable "jwt_secret_key" {
+  type    = string
+  default = ""
+}
+
+variable "supabase_url" {
+  type    = string
+  default = ""
+}
+
 variable "image_tag" {
   type    = string
   default = "latest"


### PR DESCRIPTION
## Summary

- **CORS エラー修正**: `CLIENT_URL` / `JWT_SECRET_KEY` を ECS タスク定義の環境変数に追加
- **CloudFront URL 書き換え**: `/doctor/edit-patient/[id]` / `/doctor/edit-doctor/[id]` を静的プレースホルダー（`0`）にリダイレクト
- **medical-records ページ**: `searchParams` + `cookies()` 依存をクライアントコンポーネントに移行（静的エクスポート対応）
- **Supabase→RDS データ移行スクリプト**: コンテナ起動時に自動実行・SSL 対応・`delFlag` カラムの大文字小文字修正
- **aws-apply / aws-build-push スクリプト**: `SUPABASE_URL` を `backend/.env` の `DATABASE_URL` から自動取得

## Test plan

- [ ] ログイン画面が表示される
- [ ] ログインできる（Supabase のメール/パスワードで）
- [ ] 患者一覧・医師一覧が表示される
- [ ] 診察記録ページ（`/doctor/medical-records?patients_id=1`）が表示される
- [ ] 編集画面（`/doctor/edit-patient/[id]`）が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)